### PR TITLE
fix #22: check for nil ptr in destination rule auditor

### DIFF
--- a/_fixtures/destinationrule-empty-tls.yaml
+++ b/_fixtures/destinationrule-empty-tls.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: empty-tls-policy
+  namespace: default
+spec:
+  host: example.com
+  trafficPolicy: {}

--- a/_fixtures/destinationrule-empty-traffic-policy.yaml
+++ b/_fixtures/destinationrule-empty-traffic-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: empty-traffic-policy
+  namespace: default
+spec:
+  host: example.com

--- a/auditors/destinationrule/cacerts.go
+++ b/auditors/destinationrule/cacerts.go
@@ -44,6 +44,9 @@ func (a *auditor) Audit(_ types.Discovery, resources types.Resources) ([]types.A
 	var results []types.AuditResult
 
 	for _, rule := range resources.DestinationRules {
+		if rule.Spec.TrafficPolicy == nil {
+			continue
+		}
 		if !isClientTLSSettingSafe(rule.Spec.TrafficPolicy.Tls) {
 			results = append(results, types.AuditResult{
 				Name:        a.Name(),


### PR DESCRIPTION
Adds nil ptr checks for the traffic policy in destination rule processing.