### PR TITLE
fix: typo

### DIFF
--- a/auditors/peerauth/mutual_tls.go
+++ b/auditors/peerauth/mutual_tls.go
@@ -30,7 +30,7 @@ func init() {
 type auditor struct{}
 
 func (a *auditor) Name() string {
-	return "Permissive Mututal TLS"
+	return "Permissive Mutual TLS"
 }
 
 func (a *auditor) Audit(_ types.Discovery, resources types.Resources) ([]types.AuditResult, error) {


### PR DESCRIPTION
Fixes typo `Mututal` to `Mutual`